### PR TITLE
Sugarchain: add: Yespower Cache PoW hashes

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -227,9 +227,9 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
-    //! (memory only)
-    bool cacheInit;
-    uint256 cacheIndexHash, cacheWorkHash;
+    //! (currently memory only, but don't have to be)
+    bool cache_init;
+    uint256 cache_block_hash, cache_PoW_hash;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -259,7 +259,7 @@ public:
         nBits          = 0;
         nNonce         = 0;
 
-        cacheInit     = false;
+        cache_init     = false;
     }
 
     CBlockIndex()
@@ -277,9 +277,9 @@ public:
         nBits          = block.nBits;
         nNonce         = block.nNonce;
 
-        cacheInit     = block.cacheInit;
-        cacheIndexHash = block.cacheIndexHash;
-        cacheWorkHash = block.cacheWorkHash;
+        cache_init     = block.cache_init;
+        cache_block_hash = block.cache_block_hash;
+        cache_PoW_hash = block.cache_PoW_hash;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -311,9 +311,9 @@ public:
         block.nBits          = nBits;
         block.nNonce         = nNonce;
 
-        block.cacheInit     = cacheInit;
-        block.cacheIndexHash = cacheIndexHash;
-        block.cacheWorkHash = cacheWorkHash;
+        block.cache_init     = cache_init;
+        block.cache_block_hash = cache_block_hash;
+        block.cache_PoW_hash = cache_PoW_hash;
 
         return block;
     }

--- a/src/chain.h
+++ b/src/chain.h
@@ -227,6 +227,10 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
+    //! (memory only)
+    bool cacheInit;
+    uint256 cacheIndexHash, cacheWorkHash;
+
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
 
@@ -254,6 +258,8 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
+
+        cacheInit     = false;
     }
 
     CBlockIndex()
@@ -270,6 +276,10 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+
+        cacheInit     = block.cacheInit;
+        cacheIndexHash = block.cacheIndexHash;
+        cacheWorkHash = block.cacheWorkHash;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -300,6 +310,11 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+
+        block.cacheInit     = cacheInit;
+        block.cacheIndexHash = cacheIndexHash;
+        block.cacheWorkHash = cacheWorkHash;
+
         return block;
     }
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -53,14 +53,14 @@ uint256 CBlockHeader::GetPoWHash_cached() const
             fprintf(stderr, "Error: CBlockHeader: block hash changed unexpectedly\n");
             exit(1);
         }
-        // yespower cache: log
-        printf("HIT block_hash = %s PoW_hash = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
+        // yespower cache: log // O (cyan) = HIT
+        printf("\033[36;1mO\033[0m block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
     } else {
         cache_PoW_hash = GetPoWHash();
         cache_block_hash = block_hash;
         cache_init = true;
-        // yespower cache: log
-        printf("MISS block_hash = %s PoW_hash = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
+        // yespower cache: log // x = MISS
+        printf("x block = %s PoW = %s\n", cache_block_hash.ToString().c_str(), cache_PoW_hash.ToString().c_str());
     }
     return cache_PoW_hash;
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -9,6 +9,8 @@
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
+
+// yespower cache
 #include <sync.h>
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
@@ -74,13 +76,13 @@ public:
 class CBlockHeader : public CBlockHeaderUncached
 {
 public:
-    mutable CCriticalSection cacheLock;
-    mutable bool cacheInit;
-    mutable uint256 cacheIndexHash, cacheWorkHash;
+    mutable CCriticalSection cache_lock;
+    mutable bool cache_init;
+    mutable uint256 cache_block_hash, cache_PoW_hash;
 
     CBlockHeader()
     {
-        cacheInit = false;
+        cache_init = false;
     }
 
     CBlockHeader(const CBlockHeader& header)
@@ -91,13 +93,13 @@ public:
     CBlockHeader& operator=(const CBlockHeader& header)
     {
         *(CBlockHeaderUncached*)this = (CBlockHeaderUncached)header;
-        cacheInit = header.cacheInit;
-        cacheIndexHash = header.cacheIndexHash;
-        cacheWorkHash = header.cacheWorkHash;
+        cache_init = header.cache_init;
+        cache_block_hash = header.cache_block_hash;
+        cache_PoW_hash = header.cache_PoW_hash;
         return *this;
     }
 
-    uint256 GetPoWHashCached() const;
+    uint256 GetPoWHash_cached() const;
 };
 
 class CBlock : public CBlockHeader

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2013-2019 Alexander Peslyak - Yespower 1.0.1
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -1120,7 +1121,7 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetPoWHashCached(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 
     return true;
@@ -3042,7 +3043,7 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetPoWHashCached(), block.nBits, consensusParams))
+    if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;
@@ -3498,19 +3499,22 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 {
     AssertLockNotHeld(cs_main);
 
+    // Look for this block's header in the index like AcceptBlock() will
     uint256 hash = pblock->GetHash();
+
     {
         LOCK(cs_main);
+
         BlockMap::iterator miSelf = mapBlockIndex.find(hash);
         CBlockIndex *pindex = NULL;
         if (miSelf != mapBlockIndex.end()) {
             // Block header is already known
             pindex = miSelf->second;
-            if (!pblock->cacheInit && pindex->cacheInit) {
-                LOCK(pblock->cacheLock);
-                pblock->cacheInit = true;
-                pblock->cacheIndexHash = pindex->cacheIndexHash;
-                pblock->cacheWorkHash = pindex->cacheWorkHash;
+            if (!pblock->cache_init && pindex->cache_init) {
+                LOCK(pblock->cache_lock); // Probably unnecessary since no concurrent access to pblock is expected
+                pblock->cache_init = true;
+                pblock->cache_block_hash = pindex->cache_block_hash;
+                pblock->cache_PoW_hash = pindex->cache_PoW_hash;
             }
         }
     }


### PR DESCRIPTION
# Originary implemented by 

https://github.com/ResistancePlatform/resistance-core/commit/a73d69465c8884e6289ecbdec58331e8fdc0376a
https://github.com/ResistancePlatform/resistance-core/commit/3c80dac3618e42c90057da7ba6fa49c44cf64349
https://github.com/ResistancePlatform/resistance-core/compare/20c7ba33101133053bd001a84479ff341a134cba...3c80dac3618e42c90057da7ba6fa49c44cf64349

-----

# Result

- IBD `3x` faster `7:30`
![image](https://user-images.githubusercontent.com/37016180/71312484-e0847100-246e-11ea-9d64-aff3a4c23acb.png)

- reindex `2.4x` faster `9:00`
![image](https://user-images.githubusercontent.com/37016180/71312493-ec703300-246e-11ea-9a51-4aa7d6270361.png)

-----

# Testing
- [x] rename: `GetPoWHashCached()` to `GetPoWHash_cached()` by original author (trivial)
- [x] make check: OK
- [x] test_bitcoin: OK
- [x] IBD: OK: took `7h30m at height 1858419` ***300% faster***
  * [x] UNCACHED: IBD: OK: took `22h20m at height 1874686`
- [x] `-reindex` OK: took `3h15m+3h25m==6h40m at height 1814177` ***200% faster***
  * [x] UNCACHED: `-reindex` OK: took `13h20m (6:40+6:40) at height 1843981`
- [x] `-reindex-chainstate` OK: took `3h40m at height 1809089` ***170% faster***
  * [x] UNCACHED `-reindex-chainstate` OK: took `6h13m at height 1828078`
- [ ] import bootstrap
- [ ] benchmark vs non-cache (at least 3 times)
  * [x] IBD
  * [x] reindex
  * [ ] reindex-chainstate

-----

# Log

```
X block = cba1cfff0fd1bc43ba5508f3113502d1f77c803afd9ca295e1ad2303ba80397e PoW = 000004e5ef92746b970adde07576e89f8f73434efc67cb7704fd0021bdcb5265
O block = cba1cfff0fd1bc43ba5508f3113502d1f77c803afd9ca295e1ad2303ba80397e PoW = 000004e5ef92746b970adde07576e89f8f73434efc67cb7704fd0021bdcb5265
X block = a3f0556b4db92179d5bf961f9c16406886a669b522caf43a18d6ad48b0b7490d PoW = 00000167626529c9ce87bb85e40f8f992359fb31ebdc9af49dbf1cb7ef2db6a1
O block = a3f0556b4db92179d5bf961f9c16406886a669b522caf43a18d6ad48b0b7490d PoW = 00000167626529c9ce87bb85e40f8f992359fb31ebdc9af49dbf1cb7ef2db6a1
X block = ed8461b33a2534f537d7a07e95c6dd9fa7f9915c3761ebd16f4cebc562e8b14c PoW = 000006b5c8d01e40596a914d0235d79bc9d4402e4c6665353440bc02b60697aa
O block = ed8461b33a2534f537d7a07e95c6dd9fa7f9915c3761ebd16f4cebc562e8b14c PoW = 000006b5c8d01e40596a914d0235d79bc9d4402e4c6665353440bc02b60697aa
X block = b32e64b7f26282eb2bf4990e4f03b83b6644ad71af3919aa89c5f87687f463c8 PoW = 0000004271c1f17d3f4c96bad6d69360b19bde4a9fdeacae01767768f7591ec9
O block = b32e64b7f26282eb2bf4990e4f03b83b6644ad71af3919aa89c5f87687f463c8 PoW = 0000004271c1f17d3f4c96bad6d69360b19bde4a9fdeacae01767768f7591ec9
X block = 031bc4827cec6b1b56292e870278b4d103150c51634f22d954fced9ec78dd153 PoW = 0000079b8815fe58bc73c99d60240b69e4aefa8623c4314599efbfb7af02aaa5
O block = 031bc4827cec6b1b56292e870278b4d103150c51634f22d954fced9ec78dd153 PoW = 0000079b8815fe58bc73c99d60240b69e4aefa8623c4314599efbfb7af02aaa5
X block = c7d37106b96c8e9e11d57a3b06ace1a3535cac972b7672602f98e1befad5db08 PoW = 000006323eab4101ef2445c6b8fdb713e11f9cfbb0be8d9a35fd1a878eeaf9b1
O block = c7d37106b96c8e9e11d57a3b06ace1a3535cac972b7672602f98e1befad5db08 PoW = 000006323eab4101ef2445c6b8fdb713e11f9cfbb0be8d9a35fd1a878eeaf9b1
X block = 34960049b2238e9ea079726ea713b21891984effedd5fc3be8e11bf55f7f8d88 PoW = 000002f51a41a53258bfc5a8b2659cc69da4ee931ecec7e4717833d09930c1e3
O block = 34960049b2238e9ea079726ea713b21891984effedd5fc3be8e11bf55f7f8d88 PoW = 000002f51a41a53258bfc5a8b2659cc69da4ee931ecec7e4717833d09930c1e3
X block = 2208b3e7de6591904c3a658d378f8a2713287919b736e9a0d1a1ed007dab76ee PoW = 00000430a393799e7db231169536868cf3a9146716039374c1e738a8b2e875fa
O block = 2208b3e7de6591904c3a658d378f8a2713287919b736e9a0d1a1ed007dab76ee PoW = 00000430a393799e7db231169536868cf3a9146716039374c1e738a8b2e875fa
X block = 8060d16d884d5631b012ff95507838b973a6c8be80b99ee3854d81a3867e666d PoW = 000006f24bc50a78842bd7c65691520ac2e263c64c3c799d1d81246d8b4707a7
O block = 8060d16d884d5631b012ff95507838b973a6c8be80b99ee3854d81a3867e666d PoW = 000006f24bc50a78842bd7c65691520ac2e263c64c3c799d1d81246d8b4707a7
X block = fab57cbb173d49f17e24b9672aa854300300cd8d3939d5562db66ba3f9aea19b PoW = 00000476e2a983b0ba617d5c290c469638760f676248c65ffeb7d8714213b31f
O block = fab57cbb173d49f17e24b9672aa854300300cd8d3939d5562db66ba3f9aea19b PoW = 00000476e2a983b0ba617d5c290c469638760f676248c65ffeb7d8714213b31f
X block = 3a8f9c58dcfd397fede17e9dc7fd23c0667b26a847ca3bbccddf6d567358fa7c PoW = 0000085dc5a994da2d4cc161ad4110d720043c553665bee67a25166a2cbfe134
O block = 3a8f9c58dcfd397fede17e9dc7fd23c0667b26a847ca3bbccddf6d567358fa7c PoW = 0000085dc5a994da2d4cc161ad4110d720043c553665bee67a25166a2cbfe134
```

- Sync Log
https://youtu.be/MojeGzy2NHU

-----

# TODO
- [ ] remove: `printf` in `block.cpp`