### PR TITLE
Revert "add: gcc compiler warning on BTC"

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -48,13 +48,13 @@ static int ec_privkey_import_der(const secp256k1_context* ctx, unsigned char *ou
     if (lenb < 1 || lenb > 2) {
         return 0;
     }
-    if (end - privkey < lenb) { // FIXME.SUGAR // BTC issue
+    if (end - privkey < lenb) {
         return 0;
     }
     /* sequence length */
     size_t len = privkey[lenb-1] | (lenb > 1 ? privkey[lenb-2] << 8 : 0u);
     privkey += lenb;
-    if (end - privkey < len) { // FIXME.SUGAR // BTC issue
+    if (end - privkey < len) {
         return 0;
     }
     /* sequence element 0: version number (=1) */
@@ -68,7 +68,7 @@ static int ec_privkey_import_der(const secp256k1_context* ctx, unsigned char *ou
     }
     size_t oslen = privkey[1];
     privkey += 2;
-    if (oslen > 32 || end - privkey < oslen) { // FIXME.SUGAR // BTC issue
+    if (oslen > 32 || end - privkey < oslen) {
         return 0;
     }
     memcpy(out32 + (32 - oslen), privkey, oslen);

--- a/src/leveldb/port/port_posix.cc
+++ b/src/leveldb/port/port_posix.cc
@@ -57,7 +57,7 @@ bool HasAcceleratedCRC32C() {
 #if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
   unsigned int eax, ebx, ecx, edx;
   __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-  return (ecx & (1 << 20)) != 0; // FIXME.SUGAR // BTC issue
+  return (ecx & (1 << 20)) != 0;
 #else
   return false;
 #endif

--- a/src/leveldb/util/logging.cc
+++ b/src/leveldb/util/logging.cc
@@ -55,7 +55,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
       const int delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
-          (v == kMaxUint64/10 && delta > kMaxUint64%10)) { // FIXME.SUGAR // BTC issue
+          (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
         // Overflow
         return false;
       }


### PR DESCRIPTION
Reverts sugarchain-project/sugarchain#65

https://travis-ci.org/sugarchain-project/sugarchain/jobs/647982432?utm_medium=notification&utm_source=github_status

> The command "if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/leveldb; fi" failed and exited with 1 during .

this breaks travis. should revert.