### PR TITLE
Sugarchain: fix: do not disconnect whitelisted peers during IBD

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -56,7 +56,7 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes */
-static const int MAX_OUTBOUND_CONNECTIONS = 8*2; // FIXME.SUGAR // (was 8) increasing outbound to make sync faster
+static const int MAX_OUTBOUND_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** -listen default */

--- a/src/net.h
+++ b/src/net.h
@@ -56,7 +56,7 @@ static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes */
-static const int MAX_OUTBOUND_CONNECTIONS = 8;
+static const int MAX_OUTBOUND_CONNECTIONS = 8*2; // FIXME.SUGAR // (was 8) increasing outbound to make sync faster
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** -listen default */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3588,7 +3588,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // no peer disconnect during IBD
+                    if (!pto->fWhitelisted) {
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3129,10 +3129,10 @@ void PeerLogicValidation::CheckForStaleTipAndEvictPeers(const Consensus::Params 
         // Check whether our tip is stale, and if so, allow using an extra
         // outbound peer
         if (TipMayBeStale(consensusParams)) {
-            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD
+            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD // no disconnect during IBD
                 LogPrintf("Potential stale tip detected, will try using extra outbound peer (last tip update: %d seconds ago)\n", time_in_seconds - g_last_tip_update);
+                connman->SetTryNewOutboundPeer(true); // FIXME.SUGAR // no disconnect during IBD
             }
-            connman->SetTryNewOutboundPeer(true);
         } else if (connman->GetTryNewOutboundPeer()) {
             connman->SetTryNewOutboundPeer(false);
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3581,14 +3581,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Check for headers sync timeouts
         if (state.fSyncStarted && state.nHeadersSyncTimeout < std::numeric_limits<int64_t>::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
-            if (pindexBestHeader->GetBlockTime() <= GetAdjustedTime() - (24*60*60)*120) { // FIXME.SUGAR // 120x bitcoin // prevent disconnect peers during IBD
+            if (pindexBestHeader->GetBlockTime() <= GetAdjustedTime() - 24*60*60) {
                 if (nNow > state.nHeadersSyncTimeout && nSyncStarted == 1 && (nPreferredDownload - state.fPreferredDownload >= 1)) {
                     // Disconnect a (non-whitelisted) peer if it is our only sync peer,
                     // and we have others we could be using instead.
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted) {
+                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // no peer disconnect during IBD
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3581,7 +3581,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Check for headers sync timeouts
         if (state.fSyncStarted && state.nHeadersSyncTimeout < std::numeric_limits<int64_t>::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
-            if (pindexBestHeader->GetBlockTime() <= GetAdjustedTime() - 24*60*60) {
+            if (pindexBestHeader->GetBlockTime() <= GetAdjustedTime() - (24*60*60)*120) { // FIXME.SUGAR // 120x bitcoin // prevent disconnect peers during IBD
                 if (nNow > state.nHeadersSyncTimeout && nSyncStarted == 1 && (nPreferredDownload - state.fPreferredDownload >= 1)) {
                     // Disconnect a (non-whitelisted) peer if it is our only sync peer,
                     // and we have others we could be using instead.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3588,7 +3588,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // no peer disconnect during IBD
+                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // do not disconnect whitelisted peers during IBD
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3129,10 +3129,10 @@ void PeerLogicValidation::CheckForStaleTipAndEvictPeers(const Consensus::Params 
         // Check whether our tip is stale, and if so, allow using an extra
         // outbound peer
         if (TipMayBeStale(consensusParams)) {
-            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD // no disconnect during IBD
+            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD
                 LogPrintf("Potential stale tip detected, will try using extra outbound peer (last tip update: %d seconds ago)\n", time_in_seconds - g_last_tip_update);
-                connman->SetTryNewOutboundPeer(true); // FIXME.SUGAR // no disconnect during IBD
             }
+            connman->SetTryNewOutboundPeer(true);
         } else if (connman->GetTryNewOutboundPeer()) {
             connman->SetTryNewOutboundPeer(false);
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3588,7 +3588,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted) {
+                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // no peer disconnect during IBD
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1397,7 +1397,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         }
 
         // FIXME.SUGAR
-        // 120x bitcoin // disable additional download traffic during IBD
+        // 120x bitcoin // IBD: disable additional download during IBD, due to too much traffic
         /*
         if (nCount == MAX_HEADERS_RESULTS) {
             // Headers message had its maximum size; the peer may have more headers.
@@ -3129,7 +3129,7 @@ void PeerLogicValidation::CheckForStaleTipAndEvictPeers(const Consensus::Params 
         // Check whether our tip is stale, and if so, allow using an extra
         // outbound peer
         if (TipMayBeStale(consensusParams)) {
-            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD
+            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // IBD: do not print this connection log during IBD
                 LogPrintf("Potential stale tip detected, will try using extra outbound peer (last tip update: %d seconds ago)\n", time_in_seconds - g_last_tip_update);
             }
             connman->SetTryNewOutboundPeer(true);
@@ -3588,7 +3588,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // do not disconnect whitelisted peers during IBD
+                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // IBD: do not disconnect *whitelisted* peers during IBD
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -21,7 +21,7 @@
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
 
-#include <validation.h> // FIXME.SUGAR // for IsInitialBlockDownload
+#include <validation.h> // FIXME.SUGAR // IBD: for IsInitialBlockDownload()
 
 #if !defined(HAVE_MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0
@@ -515,7 +515,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const SOCKET& hSocket, i
             }
             if (nRet != 0)
             {
-                if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD
+                if (!IsInitialBlockDownload()) { // FIXME.SUGAR // IBD: do not print this connection log during IBD
                     LogPrintf("connect() to %s failed after select(): %s\n", addrConnect.ToString(), NetworkErrorString(nRet));
                 }
                 return false;
@@ -527,7 +527,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const SOCKET& hSocket, i
         else
 #endif
         {
-            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // LOG_DISABLED during IBD
+            if (!IsInitialBlockDownload()) { // FIXME.SUGAR // IBD: do not print this connection log during IBD
                 LogPrintf("connect() to %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
             }
             return false;


### PR DESCRIPTION
### discussion
`Timeout downloading headers from peer=0, disconnecting` VS `Timeout downloading headers from whitelisted peer=0, not disconnecting`

### result: 9b5c0cb
- 9b5c0cb : `10:00 (16% faster)` :heavy_check_mark: 
- 827b0bd : `10:20 (12% faster)`
- cee8630 : `10:35 (10% faster)`
- old RC3 2a0ecad22bd3b2dffb649b2ef0ecb3ce89417bcc: `11:40`


### benchmark
![image](https://user-images.githubusercontent.com/60179867/74603121-806b1d80-50f3-11ea-8b6c-a9e0c6f89a1e.png)

9b5c0cb is the best

### traffic
![image](https://user-images.githubusercontent.com/60179867/74603532-a5fa2600-50f7-11ea-977a-ed46f82d8ddc.png)

### peers
![image](https://user-images.githubusercontent.com/60179867/74603542-c6c27b80-50f7-11ea-9915-e74c28ff81c6.png)

### mid log
![image](https://user-images.githubusercontent.com/60179867/74583381-e8453980-5009-11ea-95d1-37cd6b6bf9b6.png)

![image](https://user-images.githubusercontent.com/60179867/74583395-0ad75280-500a-11ea-9e09-4fd0899d4b71.png)

### Log for Timeout downloading
- 9b5c0cb
```
$ grep "Timeout downloading headers" /mnt/ssd120g/TEST-SUGAR/.sugarchain-9b5c0cb/debug.log 
2020-02-16 00:52:15 Timeout downloading headers from whitelisted peer=0, not disconnecting
2020-02-16 01:46:14 Timeout downloading headers from whitelisted peer=1, not disconnecting
2020-02-16 02:44:35 Timeout downloading headers from whitelisted peer=1, not disconnecting
2020-02-16 03:19:00 Timeout downloading headers from whitelisted peer=3, not disconnecting
2020-02-16 03:47:36 Timeout downloading headers from whitelisted peer=4, not disconnecting
2020-02-16 04:11:19 Timeout downloading headers from whitelisted peer=5, not disconnecting
2020-02-16 04:31:09 Timeout downloading headers from whitelisted peer=6, not disconnecting
```

- 827b0bd 
```
$ grep "Timeout downloading headers" /mnt/ssd120g/TEST-SUGAR/.sugarchain-827b0bd/debug.log
```
NO RESULTS

- cee8630
```
$ grep "Timeout downloading headers" /mnt/ssd120g/TEST-SUGAR/.sugarchain-cee8630/debug.log
2020-02-16 00:47:49 Timeout downloading headers from peer=0, disconnecting
2020-02-16 01:42:05 Timeout downloading headers from peer=1, disconnecting
2020-02-16 02:27:17 Timeout downloading headers from peer=2, disconnecting
2020-02-16 03:04:49 Timeout downloading headers from peer=3, disconnecting
2020-02-16 03:35:53 Timeout downloading headers from peer=8, disconnecting
2020-02-16 04:01:44 Timeout downloading headers from peer=5, disconnecting
2020-02-16 04:28:41 Timeout downloading headers from peer=25, disconnecting
```