### PR TITLE
add: -disabledebuglogfile as an option (1)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -475,6 +475,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
+    strUsage += HelpMessageOpt("-disabledebuglogfile", _("Do not create debug.log file to save disk space")); // FIXME.SUGAR // add disable "debug.log" // REMOVE after BTC 0.17
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY));
@@ -829,6 +830,7 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 void InitLogging()
 {
     fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", false);
+    fDisableDebugLog = gArgs.GetBoolArg("-disabledebuglogfile", false); // FIXME.SUGAR // add disable "debug.log" // REMOVE after BTC 0.17
     fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,6 +88,7 @@ const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
 ArgsManager gArgs;
 bool fPrintToConsole = false;
+bool fDisableDebugLog = false; // FIXME.SUGAR // add disable "debug.log" // REMOVE after BTC 0.17
 bool fPrintToDebugLog = true;
 
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
@@ -349,6 +350,10 @@ int LogPrintStr(const std::string &str)
         // print to console
         ret = fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
         fflush(stdout);
+    }
+    else if (fDisableDebugLog) // FIXME.SUGAR // add disable "debug.log" // REMOVE after BTC 0.17
+    {
+        // do nothing
     }
     else if (fPrintToDebugLog)
     {

--- a/src/util.h
+++ b/src/util.h
@@ -48,6 +48,7 @@ public:
 };
 
 extern bool fPrintToConsole;
+extern bool fDisableDebugLog; // FIXME.SUGAR // add disable "debug.log" // REMOVE after BTC 0.17
 extern bool fPrintToDebugLog;
 
 extern bool fLogTimestamps;


### PR DESCRIPTION
debug:
`watch -n5 ls -lh debug.log`

however no debug file didn't improve the speed when `reindex-chainstate`
![image](https://user-images.githubusercontent.com/60179867/79673769-9e4e1f00-8217-11ea-96b6-c3a968541c56.png)

- Linux64: Tested
- Win: not yet
- OSX: not yet