### PR TITLE
add: option "-prunedebuglogfile": limit filesize of debug.log

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -475,6 +475,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
+    strUsage += HelpMessageOpt("-prunedebuglogfile", _("Limit filesize of debug.log"));
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -475,7 +475,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees (in %s) to use in a single wallet transaction or raw transaction; setting this too low may abort large transactions (default: %s)"),
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
-    strUsage += HelpMessageOpt("-prunedebuglogfile", _("Limit filesize of debug.log"));
+    strUsage += HelpMessageOpt("-prunedebuglogfile", _("Prune (limit) filesize of debug.log")); // FIXME.SUGAR // prune debug.log
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY));
@@ -830,7 +830,7 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 void InitLogging()
 {
     fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", false);
-    fPruneDebugLog = gArgs.GetBoolArg("-prunedebuglogfile", false);
+    fPruneDebugLog = gArgs.GetBoolArg("-prunedebuglogfile", false); // FIXME.SUGAR // prune debug.log
     fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -829,6 +829,7 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 void InitLogging()
 {
     fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", false);
+    fPruneDebugLog = gArgs.GetBoolArg("-prunedebuglogfile", false);
     fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -89,7 +89,7 @@ const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 ArgsManager gArgs;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
-bool fPruneDebugLog = false;
+bool fPruneDebugLog = false; // FIXME.SUGAR // prune debug.log
 
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
@@ -351,7 +351,7 @@ int LogPrintStr(const std::string &str)
         ret = fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
         fflush(stdout);
     }
-    else if (fPrintToDebugLog && !fPruneDebugLog) // do not pruning (original)
+    else if (fPrintToDebugLog && !fPruneDebugLog) // do not pruning (original) // FIXME.SUGAR // prune debug.log
     {
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
         boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
@@ -375,7 +375,7 @@ int LogPrintStr(const std::string &str)
             ret = FileWriteStr(strTimestamped, fileout);
         }
     }
-    else if (fPrintToDebugLog && fPruneDebugLog) // pruning
+    else if (fPrintToDebugLog && fPruneDebugLog) // pruning // FIXME.SUGAR // prune debug.log
     {
         boost::call_once(&DebugPrintInit, debugPrintInitFlag);
         boost::mutex::scoped_lock scoped_lock(*mutexDebugLog);
@@ -399,7 +399,7 @@ int LogPrintStr(const std::string &str)
             ret = FileWriteStr(strTimestamped, fileout);
         }
 
-        // BEGIN - PRUNE LOG
+        // BEGIN - PRUNE DEBUG.LOG
         // If debug.log is over 1mb (1000*1000), shrink to 1k (1000)
         {
             // Amount of debug.log to save at end when shrinking (must fit in memory)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -378,7 +378,7 @@ int LogPrintStr(const std::string &str)
         // BEGIN - PRUNE DEBUG.LOG
         // If debug.log is over 10 MB (10*1000*1000), shrink to 1 MB (1*1000*1000)
         // see "void ShrinkDebugFile()"
-        if (fPruneDebugLog)
+        if (fPrintToDebugLog && fPruneDebugLog && !fPrintToConsole)
         {
             {
                 // Amount of debug.log to save at end when shrinking (must fit in memory)
@@ -391,7 +391,7 @@ int LogPrintStr(const std::string &str)
                 if (file && fs::file_size(pathLog) > 10 * RECENT_DEBUG_HISTORY_SIZE) // was (11 * (RECENT_DEBUG_HISTORY_SIZE / 10)))
                 {
                     // BEGIN - DEBUG FILESIZE
-                    printf("%s ** DEBUG.LOG PRUNED ** %lu\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), fs::file_size(pathLog));
+                    printf("%s DEBUG.LOG PRUNED at %lu\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), fs::file_size(pathLog));
                     // END - DEBUG FILESIZE
 
                     // Restart the file with some of the end

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -400,19 +400,19 @@ int LogPrintStr(const std::string &str)
         }
 
         // BEGIN - PRUNE DEBUG.LOG
-        // If debug.log is over 1mb (1000*1000), shrink to 1k (1000)
+        // If debug.log is over 10 MB (10*1000*1000), shrink to 1 MB (1*1000*1000)
         {
             // Amount of debug.log to save at end when shrinking (must fit in memory)
-            constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 1000; // was (10 * 1000000)
+            constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 1*1000*1000; // was (10 * 1000000)
             // Scroll debug.log if it's getting too big
             fs::path pathLog = GetDebugLogPath();
             FILE* file = fsbridge::fopen(pathLog, "r");
-            // If debug.log file is more than 1000% bigger the RECENT_DEBUG_HISTORY_SIZE
+            // If debug.log file is more than 10x bigger the RECENT_DEBUG_HISTORY_SIZE
             // trim it down by saving only the last RECENT_DEBUG_HISTORY_SIZE bytes
-            if (file && fs::file_size(pathLog) > 1000.0 * RECENT_DEBUG_HISTORY_SIZE) // was (11 * (RECENT_DEBUG_HISTORY_SIZE / 10)))
+            if (file && fs::file_size(pathLog) > 10 * RECENT_DEBUG_HISTORY_SIZE) // was (11 * (RECENT_DEBUG_HISTORY_SIZE / 10)))
             {
                 // BEGIN - DEBUG FILESIZE
-                printf("*** PRUNED = %lu ***\n", fs::file_size(pathLog));
+                printf("%s ** DEBUG.LOG PRUNED ** %lu\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), fs::file_size(pathLog));
                 // END - DEBUG FILESIZE
 
                 // Restart the file with some of the end

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -375,6 +375,7 @@ int LogPrintStr(const std::string &str)
             ret = FileWriteStr(strTimestamped, fileout);
         }
 
+        // FIXME.SUGAR // prune debug.log
         // BEGIN - PRUNE DEBUG.LOG
         // If debug.log is over 10 MB (10*1000*1000), shrink to 1 MB (1*1000*1000)
         // see "void ShrinkDebugFile()"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -89,6 +89,7 @@ const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 ArgsManager gArgs;
 bool fPrintToConsole = false;
 bool fPrintToDebugLog = true;
+bool fPruneDebugLog = false;
 
 bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
@@ -373,17 +374,19 @@ int LogPrintStr(const std::string &str)
 
             ret = FileWriteStr(strTimestamped, fileout);
         }
+
+        // prune the log file, if requested
+        if (fPruneDebugLog) {
+            PruneDebugFile();
+
+            // REMOVE THIS LOG
+            if (ret > 100) {
+                fs::path pathLog = GetDebugLogPath();
+                printf("***** fs::file_size(pathLog) = %lu *****\n", fs::file_size(pathLog));
+                // LogPrintf("***** fs::file_size(pathLog) = %d *****\n", fs::file_size(pathLog));
+            }
+        }
     }
-
-    PruneDebugFile();
-
-    // REMOVE THIS LOG
-    if (ret > 100) {
-        fs::path pathLog = GetDebugLogPath();
-        printf("***** fs::file_size(pathLog) = %lu *****\n", fs::file_size(pathLog));
-        // LogPrintf("***** fs::file_size(pathLog) = %d *****\n", fs::file_size(pathLog));
-    }
-
     return ret;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -374,6 +374,16 @@ int LogPrintStr(const std::string &str)
             ret = FileWriteStr(strTimestamped, fileout);
         }
     }
+
+    PruneDebugFile();
+
+    // REMOVE THIS LOG
+    if (ret > 100) {
+        fs::path pathLog = GetDebugLogPath();
+        printf("***** fs::file_size(pathLog) = %lu *****\n", fs::file_size(pathLog));
+        // LogPrintf("***** fs::file_size(pathLog) = %d *****\n", fs::file_size(pathLog));
+    }
+
     return ret;
 }
 
@@ -837,6 +847,36 @@ void ShrinkDebugFile()
     // If debug.log file is more than 10% bigger the RECENT_DEBUG_HISTORY_SIZE
     // trim it down by saving only the last RECENT_DEBUG_HISTORY_SIZE bytes
     if (file && fs::file_size(pathLog) > 11 * (RECENT_DEBUG_HISTORY_SIZE / 10))
+    {
+        // Restart the file with some of the end
+        std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
+        fseek(file, -((long)vch.size()), SEEK_END);
+        int nBytes = fread(vch.data(), 1, vch.size(), file);
+        fclose(file);
+
+        file = fsbridge::fopen(pathLog, "w");
+        if (file)
+        {
+            fwrite(vch.data(), 1, nBytes, file);
+            fclose(file);
+        }
+    }
+    else if (file != nullptr)
+        fclose(file);
+}
+
+// If debug.log is over 1mb (1000*1000), shrink to 1k (1000)
+// limiting debug.log every 20 seconds in reindex-chainstate
+void PruneDebugFile()
+{
+    // Amount of debug.log to save at end when shrinking (must fit in memory)
+    constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 1000; // was (10 * 1000000)
+    // Scroll debug.log if it's getting too big
+    fs::path pathLog = GetDebugLogPath();
+    FILE* file = fsbridge::fopen(pathLog, "r");
+    // If debug.log file is more than 1000% bigger the RECENT_DEBUG_HISTORY_SIZE
+    // trim it down by saving only the last RECENT_DEBUG_HISTORY_SIZE bytes
+    if (file && fs::file_size(pathLog) > 1000.0 * RECENT_DEBUG_HISTORY_SIZE) // was (11 * (RECENT_DEBUG_HISTORY_SIZE / 10)))
     {
         // Restart the file with some of the end
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);

--- a/src/util.h
+++ b/src/util.h
@@ -49,7 +49,7 @@ public:
 
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
-extern bool fPruneDebugLog;
+extern bool fPruneDebugLog; // FIXME.SUGAR // prune debug.log
 
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;

--- a/src/util.h
+++ b/src/util.h
@@ -198,7 +198,6 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 fs::path GetDebugLogPath();
 bool OpenDebugLog();
 void ShrinkDebugFile();
-void PruneDebugFile();
 void runCommand(const std::string& strCommand);
 
 inline bool IsSwitchChar(char c)

--- a/src/util.h
+++ b/src/util.h
@@ -49,6 +49,7 @@ public:
 
 extern bool fPrintToConsole;
 extern bool fPrintToDebugLog;
+extern bool fPruneDebugLog;
 
 extern bool fLogTimestamps;
 extern bool fLogTimeMicros;

--- a/src/util.h
+++ b/src/util.h
@@ -197,6 +197,7 @@ fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 fs::path GetDebugLogPath();
 bool OpenDebugLog();
 void ShrinkDebugFile();
+void PruneDebugFile();
 void runCommand(const std::string& strCommand);
 
 inline bool IsSwitchChar(char c)


### PR DESCRIPTION
The idea is `ShrinkDebugFile` in realtime.

- AIM:
to prevent disk is filling full up with log file.

- DEBUG:
If `debug.log` is over 10 MB (`10*1000*1000`), shrink to 1 MB (`1*1000*1000`). 10x smaller
  * `watch -n1 ls -lh debug.log`
  * `watch -n5 ps -p "$(cat sugarchaind.pid)" -o %cpu,%mem,cmd`

- RUN: 
check logging speed and filesize
  * `sugarchaind -prunedebuglogfile -reindex-chainstate`

- PERIOD:
a cycle took around `4:30` when `-reindex-chainstate`
```
2020-04-20 23:18:55 DEBUG.LOG PRUNED at 10000071
2020-04-20 23:24:33 DEBUG.LOG PRUNED at 10000014
2020-04-20 23:30:11 DEBUG.LOG PRUNED at 10000018
2020-04-20 23:35:45 DEBUG.LOG PRUNED at 10000186
```