### PR TITLE
[WIP] add: print blockheader count during IBD

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3396,7 +3396,7 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
     // FIXME.SUGAR
     // display blockheader count during IBD
     if (IsInitialBlockDownload() && ppindex && *ppindex) {
-        LogPrintf("download=%d(%.1f%%)\n",
+        LogPrintf("header=%d(%.1f%%)\n",
                   (*ppindex)->nHeight, 100.0/((*ppindex)->nHeight+(GetAdjustedTime() - (*ppindex)->GetBlockTime()) / Params().GetConsensus().nPowTargetSpacing) * (*ppindex)->nHeight);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3392,6 +3392,9 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
         }
     }
     NotifyHeaderTip();
+    if (IsInitialBlockDownload() && ppindex && *ppindex)
+        LogPrintf("Synchronizing blockheaders, height: %d (~%.2f%%)\n",
+                  (*ppindex)->nHeight, 100.0/((*ppindex)->nHeight+(GetAdjustedTime() - (*ppindex)->GetBlockTime()) / Params().GetConsensus().nPowTargetSpacing) * (*ppindex)->nHeight);
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3393,9 +3393,12 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
     }
     NotifyHeaderTip();
 
-    if (IsInitialBlockDownload() && ppindex && *ppindex)
+    // FIXME.SUGAR
+    // display blockheader count during IBD
+    if (IsInitialBlockDownload() && ppindex && *ppindex) {
         LogPrintf("download=%d(%.1f%%)\n",
                   (*ppindex)->nHeight, 100.0/((*ppindex)->nHeight+(GetAdjustedTime() - (*ppindex)->GetBlockTime()) / Params().GetConsensus().nPowTargetSpacing) * (*ppindex)->nHeight);
+    }
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3392,9 +3392,11 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
         }
     }
     NotifyHeaderTip();
+
     if (IsInitialBlockDownload() && ppindex && *ppindex)
-        LogPrintf("Synchronizing blockheaders, height: %d (~%.2f%%)\n",
+        LogPrintf("download=%d(%.1f%%)\n",
                   (*ppindex)->nHeight, 100.0/((*ppindex)->nHeight+(GetAdjustedTime() - (*ppindex)->GetBlockTime()) / Params().GetConsensus().nPowTargetSpacing) * (*ppindex)->nHeight);
+
     return true;
 }
 


### PR DESCRIPTION
this PR is a part of barrystyle https://github.com/sugarchain-project/sugarchain/pull/107

increasing by `2000`

https://github.com/sugarchain-project/sugarchain/blob/43bb57c53c186541c8d6d7ef7424a26bddbb514b/src/validation.h#L88-L90

TODO:
but its output is 2~8 times duplicated. how to prevent such duplicated log? 
```
2020-04-22 10:53:20 New outbound peer connected: version: 70015, blocks=2077425, peer=2
2020-04-22 10:53:32 download=4000(0.1%)
2020-04-22 10:53:32 download=4000(0.1%)
2020-04-22 10:53:32 download=4000(0.1%)
2020-04-22 10:53:32 download=4000(0.1%)
2020-04-22 10:53:43 download=6000(0.1%)
2020-04-22 10:53:43 download=6000(0.1%)
2020-04-22 10:53:43 download=6000(0.1%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:53:55 download=8000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
2020-04-22 10:54:06 download=10000(0.2%)
```
@barrystyle 