### PR TITLE
[WIP] case split for PoW check

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3045,6 +3045,7 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
 {
     // Skip pow test until IBD is finished
     if (!IsInitialBlockDownload()) {
+        printf("%s SKIP CheckBlockHeader\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         return true;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2734,6 +2734,8 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
     if (!isOkToGoFast()) {
         printf("%s (ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    } else if (isOkToGoFast()) {
+        printf("%s NOCHECK(ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     // Write changes periodically to disk, after relay.
@@ -3387,6 +3389,8 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (!isOkToGoFast()) {
         printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    } else if (isOkToGoFast()) {
+        printf("%s NOCHECK(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     return true;
@@ -3512,6 +3516,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     if (!isOkToGoFast()) {
         printf("%s (AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    } else if (isOkToGoFast()) {
+        printf("%s NOCHECK(AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3380,10 +3380,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (ppindex)
         *ppindex = pindex;
 
-    if (!isOkToGoFast()) {
-        printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-        CheckBlockIndex(chainparams.GetConsensus());
-    }
+    CheckBlockIndex(chainparams.GetConsensus());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3044,7 +3044,7 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Skip pow test until IBD is finished
-    if (!IsInitialBlockDownload()) {
+    if (IsInitialBlockDownload()) {
         printf("%s SKIP CheckBlockHeader\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         return true;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3118,6 +3118,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (fCheckPOW && fCheckMerkleRoot)
         block.fChecked = true;
 
+    printf("%s CheckBlock\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2731,12 +2731,15 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
             break;
     } while (pindexNewTip != pindexMostWork);
 
+    /*
     if (!isOkToGoFast()) {
         printf("%s (ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
     } else if (isOkToGoFast()) {
         printf("%s NOCHECK(ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
+    */
+    CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(chainparams, state, FLUSH_STATE_PERIODIC)) {
@@ -3513,12 +3516,15 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     if (fCheckForPruning)
         FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
 
+    /*
     if (!isOkToGoFast()) {
         printf("%s (AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
     } else if (isOkToGoFast()) {
         printf("%s NOCHECK(AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
+    */
+    CheckBlockIndex(chainparams.GetConsensus());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2730,6 +2730,7 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
         if (ShutdownRequested())
             break;
     } while (pindexNewTip != pindexMostWork);
+
     if (!isOkToGoFast()) {
         printf("%s (ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3043,16 +3043,12 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
-    // Skip pow test until IBD is finished
-    if (IsInitialBlockDownload()) {
-        return true;
-    }
-
+    // moved to CheckBlock
+    /*
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
-
-    printf("%s CheckBlockHeader\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+    */
 
     return true;
 }
@@ -3068,6 +3064,11 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // redundant with the call in AcceptBlockHeader.
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
         return false;
+
+    // came from CheckBlockHeader
+    // Check proof of work matches claimed amount
+    if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
+        return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     // Check the merkle root.
     if (fCheckMerkleRoot) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2730,8 +2730,10 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
         if (ShutdownRequested())
             break;
     } while (pindexNewTip != pindexMostWork);
-    if (!isOkToGoFast())
+    if (!isOkToGoFast()) {
+        printf("%s (ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    }
 
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(chainparams, state, FLUSH_STATE_PERIODIC)) {
@@ -3381,8 +3383,10 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (ppindex)
         *ppindex = pindex;
 
-    if (!isOkToGoFast())
+    if (!isOkToGoFast()) {
+        printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    }
 
     return true;
 }
@@ -3504,8 +3508,10 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     if (fCheckForPruning)
         FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
 
-    if (!isOkToGoFast())
+    if (!isOkToGoFast()) {
+        printf("%s (AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    }
 
     return true;
 }
@@ -4217,6 +4223,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
         // no tip due to chainActive being empty!
         PruneBlockIndexCandidates();
 
+        printf("%s (RewindBlockIndex)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(params.GetConsensus());
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -216,6 +216,7 @@ uint256 hashBestBlock;
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
+bool fFastOk = true;
 bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
@@ -302,6 +303,11 @@ static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPr
 static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
 static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
+
+bool isOkToGoFast()
+{
+    return fFastOk;
+}
 
 bool CheckFinalTx(const CTransaction &tx, int flags)
 {
@@ -1236,6 +1242,7 @@ bool IsInitialBlockDownload()
         return true;
     LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
     latchToFalse.store(true, std::memory_order_relaxed);
+    fFastOk = false;
     return false;
 }
 
@@ -3043,6 +3050,10 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
+    // Skip pow test until we're near chaintip
+    if (isOkToGoFast())
+        return true;
+
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
@@ -3369,9 +3380,11 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (ppindex)
         *ppindex = pindex;
 
-    if (!IsInitialBlockDownload()) {
-        printf("%s !IsInitialBlockDownload(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+    if (!isOkToGoFast()) {
+        printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
+    } else if (isOkToGoFast()) {
+        printf("%s NOCHECK(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -216,7 +216,6 @@ uint256 hashBestBlock;
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
-bool fFastOk = true;
 bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
@@ -303,11 +302,6 @@ static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPr
 static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks = nullptr);
 static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly = false);
-
-bool isOkToGoFast()
-{
-    return fFastOk;
-}
 
 bool CheckFinalTx(const CTransaction &tx, int flags)
 {
@@ -1242,7 +1236,6 @@ bool IsInitialBlockDownload()
         return true;
     LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
     latchToFalse.store(true, std::memory_order_relaxed);
-    fFastOk = false;
     return false;
 }
 
@@ -3050,10 +3043,6 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
-    // Skip pow test until we're near chaintip
-    if (isOkToGoFast())
-        return true;
-
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
@@ -3380,11 +3369,9 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (ppindex)
         *ppindex = pindex;
 
-    if (!isOkToGoFast()) {
-        printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+    if (!IsInitialBlockDownload()) {
+        printf("%s !IsInitialBlockDownload(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
-    } else if (isOkToGoFast()) {
-        printf("%s NOCHECK(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3045,13 +3045,14 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
 {
     // Skip pow test until IBD is finished
     if (IsInitialBlockDownload()) {
-        printf("%s SKIP CheckBlockHeader\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         return true;
     }
 
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
+
+    printf("%s CheckBlockHeader\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2730,15 +2730,6 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
         if (ShutdownRequested())
             break;
     } while (pindexNewTip != pindexMostWork);
-
-    /*
-    if (!isOkToGoFast()) {
-        printf("%s (ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-        CheckBlockIndex(chainparams.GetConsensus());
-    } else if (isOkToGoFast()) {
-        printf("%s NOCHECK(ActivateBestChain)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-    }
-    */
     CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.
@@ -3516,14 +3507,6 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     if (fCheckForPruning)
         FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
 
-    /*
-    if (!isOkToGoFast()) {
-        printf("%s (AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-        CheckBlockIndex(chainparams.GetConsensus());
-    } else if (isOkToGoFast()) {
-        printf("%s NOCHECK(AcceptBlock)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
-    }
-    */
     CheckBlockIndex(chainparams.GetConsensus());
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3383,8 +3383,6 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
     if (!isOkToGoFast()) {
         printf("%s (AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(chainparams.GetConsensus());
-    } else if (isOkToGoFast()) {
-        printf("%s NOCHECK(AcceptBlockHeader)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3044,8 +3044,12 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Skip pow test until IBD is finished
+    if (!IsInitialBlockDownload()) {
+        return true;
+    }
+
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams) && !IsInitialBlockDownload())
+    if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4219,7 +4219,6 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
         // no tip due to chainActive being empty!
         PruneBlockIndexCandidates();
 
-        printf("%s (RewindBlockIndex)CheckBlockIndex\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
         CheckBlockIndex(params.GetConsensus());
     }
 


### PR DESCRIPTION
### ISSUE
- Heavy Yespower PoW check at first stage of IBD
  * bottle neck at header downloading `(CheckBlockHeader)`
  * most bottle neck at `CheckBlockHeader` when `IBD == true`

### SOLUTION
- Split and disperse the bottle neck
    * `CheckBlockHeader` if `IBD == false`
    * `CheckBlock` if `IBD == true`

### RESULT (graph coming soon)
- Header downloading: `7x` faster
- IBD: `2.5x` faster (?)

### DEBUG
- `watch -n5 ps -p "$(cat sugarchaind.pid)" -o %cpu,%mem,cmd`
- CPU usage when header downloading
  * before: over `90%`
  * after: under `7%`
