### PR TITLE
IBD: do not check PoW (Yespower) during Download headers

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3064,8 +3064,9 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     if (block.fChecked)
         return true;
 
+    // FIXME.SUGAR // check PoW: SKIPPED during downloading headers (IBD)
     // Check that the header is valid (particularly PoW).  This is mostly
-    // redundant with the call in AcceptBlockHeader.
+    // redundant with the call in AcceptBlockHeader, but when IBD mode, its SKIPPED.
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
         return false;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3051,8 +3051,8 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
     // You can see this log when IBD.
     // This means PoW check during IBD is not actually skipped, but still its checking in another places.
     // What we skipped is only when Downloading headers, but not else. This makes IBD much faster.
-    if (IsInitialBlockDownload())
-        printf("%s IBD=%d CBH=%s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), IsInitialBlockDownload(), block.GetHash().ToString().c_str());
+    // if (IsInitialBlockDownload())
+    //     printf("%s IBD=%d CBH=%s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), IsInitialBlockDownload(), block.GetHash().ToString().c_str());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3047,6 +3047,13 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
     if (fCheckPOW && !CheckProofOfWork(block.GetPoWHash_cached(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
+    // FIXME.SUGAR // check PoW: SKIPPED during downloading headers (IBD)
+    // You can see this log when IBD.
+    // This means PoW check during IBD is not actually skipped, but still its checking in another places.
+    // What we skipped is only when Downloading headers, but not else. This makes IBD much faster.
+    if (IsInitialBlockDownload())
+        printf("%s IBD=%d CBH=%s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), IsInitialBlockDownload(), block.GetHash().ToString().c_str());
+
     return true;
 }
 
@@ -3334,7 +3341,9 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
             return true;
         }
 
-        if (!CheckBlockHeader(block, state, chainparams.GetConsensus()))
+        // FIXME.SUGAR // check PoW: SKIPPED during downloading headers (IBD)
+        // IBD: do not check PoW (Yespower) during Download headers for performance reason
+        if (!IsInitialBlockDownload() && !CheckBlockHeader(block, state, chainparams.GetConsensus()))
             return error("%s: Consensus::CheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
         // Get prev block index


### PR DESCRIPTION
# Background
https://github.com/sugarchain-project/sugarchain/pull/119

# TL;DR
- CURRENT: 
  * when downloading headers, check header (PoW: Yespower)
  * bottle neck at downloading headers
- PR:
  * skip check header (PoW: Yespower), only in downloading headers
  * bottle neck gone! :tada: 

# Safe to skip?
`CheckProofOfWork()` is already multiple checking in several place. i believe that even if our node is attacked, it will defense well.

-----

# RESULT
- :heavy_check_mark: total IBD time `++23%` faster
![image](https://user-images.githubusercontent.com/60179867/81124582-c7d5ad00-8f70-11ea-96f7-edf56aab0e02.png)

- :heavy_check_mark: data traffic `--60%` reduced
  * before
    ![image](https://user-images.githubusercontent.com/60179867/81460987-de376f00-91e3-11ea-8c08-2e10175ee0f5.png)

  * after  
    ![image](https://user-images.githubusercontent.com/60179867/81461033-1dfe5680-91e4-11ea-9ab3-7051314c3f74.png)


- :heavy_check_mark: less CPU usage around `--5%` when IBD

-----

# What we are skipping?
skipped check `CheckProofOfWork()` at `pow.cpp` **when Downloading headers**
```cpp
bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
{
    bool fNegative;
    bool fOverflow;
    arith_uint256 bnTarget;

    bnTarget.SetCompact(nBits, &fNegative, &fOverflow);

    // Check range
    if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(params.powLimit))
        return false;

    // Check proof of work matches claimed amount
    if (UintToArith256(hash) > bnTarget)
        return false;

    return true;
}
```

# How to skip and when?
do not PoW check when **Downloading headers of IBD (include `fImporting` and `fReindex`)**. if not, we do not skip.
```cpp
if ( IsInitialBlockDownload() == false )
```

# Safe enough?
i believe so. its already multiple checked in `CheckBlock()` and this can be found in 4 places:

<details><summary>CLICK ME</summary>
<p>

- 1. `AcceptBlock()`
```cpp
    if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
        !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
        if (state.IsInvalid() && !state.CorruptionPossible()) {
            pindex->nStatus |= BLOCK_FAILED_VALID;
            setDirtyBlockIndex.insert(pindex);
        }
        return error("%s: %s", __func__, FormatStateMessage(state));
    }
```
- 2. `TestBlockValidity()`
```cpp
    // NOTE: CheckBlockHeader is called by CheckBlock
    if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
        return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, FormatStateMessage(state));
    if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
        return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
```

- 3. `VerifyDB()`
```cpp
        // check level 1: verify block validity
        if (nCheckLevel >= 1 && !CheckBlock(block, state, chainparams.GetConsensus()))
            return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__,
                         pindex->nHeight, pindex->GetBlockHash().ToString(), FormatStateMessage(state));
```

- 4. `ConnectBlock()`
```cpp
    // Check it again in case a previous version let a bad block in
    // NOTE: We don't currently (re-)invoke ContextualCheckBlock() or
    // ContextualCheckBlockHeader() here. This means that if we add a new
    // consensus rule that is enforced in one of those two functions, then we
    // may have let in a block that violates the rule prior to updating the
    // software, and we would NOT be enforcing the rule here. Fully solving
    // upgrade from one software version to the next after a consensus rule
    // change is potentially tricky and issue-specific (see RewindBlockIndex()
    // for one general approach that was used for BIP 141 deployment).
    // Also, currently the rule against blocks more than 2 hours in the future
    // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
    // re-enforce that rule here (at least until we make it impossible for
    // GetAdjustedTime() to go backward).
    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck))
        return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
```

</p>
</details>

# Screenshot during IBD
- 1. This means PoW check during IBD is not actually skipped, but still its checking.
![image](https://user-images.githubusercontent.com/60179867/81125282-a5dd2a00-8f72-11ea-805d-5ae5234d5d63.png)
