### PR TITLE
revert #80 do not disconnect whitelisted peers during IBD

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3589,7 +3589,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     // Note: If all our peers are inbound, then we won't
                     // disconnect our sync peer for stalling; we have bigger
                     // problems if we can't get any outbound peers.
-                    if (!pto->fWhitelisted && !IsInitialBlockDownload()) { // FIXME.SUGAR // IBD: do not disconnect *whitelisted* peers during IBD
+                    if (!pto->fWhitelisted) {
                         LogPrintf("Timeout downloading headers from peer=%d, disconnecting\n", pto->GetId());
                         pto->fDisconnect = true;
                         return true;


### PR DESCRIPTION
# AIM
revert #80 

# REASON
since #122 we do not need this previous fix. i guess huge bottle neck is already removed. we can keep this from BTC.

# RESULT
its `5%` (30 min.) slower than before. i think its a security cost, and totally acceptable.
![image](https://user-images.githubusercontent.com/60179867/81491308-11ebc500-92c8-11ea-9998-ff6419acb26d.png)

![image](https://user-images.githubusercontent.com/60179867/81491351-91799400-92c8-11ea-86f5-ae9059065c65.png)

![image](https://user-images.githubusercontent.com/60179867/81491360-ad7d3580-92c8-11ea-8ffe-410e85ad2b4b.png)
