### PR TITLE
revert(#78) & fix: disabled more getheaders

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1399,7 +1399,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
 
         // FIXME.SUGAR
         // IBD: reduce frequency of additional downloading during IBD, against too much traffic
-        if (nCount == MAX_HEADERS_RESULTS && (pindexLast->nHeight) % (MAX_HEADERS_RESULTS * 2) == 0) {
+        if (IsInitialBlockDownload() && nCount == MAX_HEADERS_RESULTS && (pindexLast->nHeight) % (MAX_HEADERS_RESULTS * 2) == 0) {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1399,7 +1399,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
 
         // FIXME.SUGAR
         // IBD: reduce frequency of additional downloading during IBD, against too much traffic
-        if (IsInitialBlockDownload() && nCount == MAX_HEADERS_RESULTS && (pindexLast->nHeight) % (MAX_HEADERS_RESULTS * 2) == 0) {
+        if (nCount == MAX_HEADERS_RESULTS && (pindexLast->nHeight) % (MAX_HEADERS_RESULTS * 2) == 0) {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1398,16 +1398,21 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         }
 
         // FIXME.SUGAR
-        // 120x bitcoin // IBD: disable additional download during IBD, due to too much traffic
-        /*
-        if (nCount == MAX_HEADERS_RESULTS) {
+        // IBD: reduce frequency of additional downloading during IBD, against too much traffic
+        if (nCount == MAX_HEADERS_RESULTS && (pindexLast->nHeight) % (MAX_HEADERS_RESULTS * 2) == 0) {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
             LogPrint(BCLog::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->GetId(), pfrom->nStartingHeight);
+            {
+                int one = nCount;
+                int two = pindexLast->nHeight;
+                int three = pfrom->GetId();
+                int four = pfrom->nStartingHeight;
+                printf("%s (%d)more getheaders (%d) to end to peer=%d (startheight:%d)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), one, two, three, four);
+            }
             connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256()));
         }
-        */
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
         // If this set of headers is valid and ends in a block with at least as

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1404,13 +1404,6 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
             LogPrint(BCLog::NET, "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->GetId(), pfrom->nStartingHeight);
-            {
-                int one = nCount;
-                int two = pindexLast->nHeight;
-                int three = pfrom->GetId();
-                int four = pfrom->nStartingHeight;
-                printf("%s (%d)more getheaders (%d) to end to peer=%d (startheight:%d)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str(), one, two, three, four);
-            }
             connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256()));
         }
 


### PR DESCRIPTION
# Background:
more getheaders is disabled against too much traffic during IBD. But try to revert with reduce call.

# AIM:
reduce too much calls, and find a good frequency

# RESULT:
![image](https://user-images.githubusercontent.com/60179867/81525235-01eae880-938f-11ea-9a51-4c85e1a6cc96.png)
![image](https://user-images.githubusercontent.com/60179867/81524965-17134780-938e-11ea-9cb2-741031f4014a.png)
![image](https://user-images.githubusercontent.com/60179867/81525058-678aa500-938e-11ea-99ac-4c593e29ac2e.png)

- downloading little faster, however its almost same.
- traffic is almost same.
- peers seems same.