### PR TITLE
IBD: Print blockheader count on debug.log

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -764,7 +764,7 @@ void BitcoinGUI::updateHeadersSyncProgressLabel()
         progressBarLabel->setText(tr("Syncing Headers (%1%)...").arg(QString::number(100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight, 'f', 1)));
 
         // FIXME.SUGAR
-        // display blockheader count during IBD
+        // IBD: Print blockheader count on debug.log
         // Start to print if the percentage is over 1.0% to make clean
         if (IsInitialBlockDownload() && (100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight) >= 1.0)
             LogPrintf("headers=%d(%.1f%%)\n", headersTipHeight, (100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -765,8 +765,9 @@ void BitcoinGUI::updateHeadersSyncProgressLabel()
 
         // FIXME.SUGAR
         // display blockheader count during IBD
-        if (IsInitialBlockDownload())
-            LogPrintf("Syncing Headers: %d (%.1f%%)\n", headersTipHeight, 100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight);
+        // Start to print if the percentage is over 1.0% to make clean
+        if (IsInitialBlockDownload() && (100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight) >= 1.0)
+            LogPrintf("headers=%d(%.1f%%)\n", headersTipHeight, (100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight));
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -32,6 +32,8 @@
 #include <ui_interface.h>
 #include <util.h>
 
+#include <validation.h> // FIXME.SUGAR // IBD: for IsInitialBlockDownload()
+
 #include <iostream>
 
 #include <QAction>
@@ -758,8 +760,14 @@ void BitcoinGUI::updateHeadersSyncProgressLabel()
     int64_t headersTipTime = clientModel->getHeaderTipTime();
     int headersTipHeight = clientModel->getHeaderTipHeight();
     int estHeadersLeft = (GetTime() - headersTipTime) / Params().GetConsensus().nPowTargetSpacing;
-    if (estHeadersLeft > HEADER_HEIGHT_DELTA_SYNC)
+    if (estHeadersLeft > HEADER_HEIGHT_DELTA_SYNC) {
         progressBarLabel->setText(tr("Syncing Headers (%1%)...").arg(QString::number(100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight, 'f', 1)));
+
+        // FIXME.SUGAR
+        // display blockheader count during IBD
+        if (IsInitialBlockDownload())
+            LogPrintf("Syncing Headers: %d (%.1f%%)\n", headersTipHeight, 100.0 / (headersTipHeight+estHeadersLeft)*headersTipHeight);
+    }
 }
 
 void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool header)


### PR DESCRIPTION
example on `debug.log`
```
2020-05-11 17:38:08 New outbound peer connected: version: 70015, blocks=4520660, peer=0
2020-05-11 17:39:12 headers=48000(1.1%)
2020-05-11 17:39:13 headers=52000(1.1%)
2020-05-11 17:39:16 headers=56000(1.2%)
2020-05-11 17:39:19 headers=60000(1.3%)
2020-05-11 17:39:25 headers=64000(1.4%)
2020-05-11 17:39:27 headers=68000(1.5%)
2020-05-11 17:39:30 headers=72000(1.6%)
2020-05-11 17:39:33 New outbound peer connected: version: 70015, blocks=4520679, peer=1
2020-05-11 17:39:39 headers=76000(1.7%)
2020-05-11 17:39:43 headers=80000(1.8%)
2020-05-11 17:39:47 New outbound peer connected: version: 70015, blocks=4520681, peer=2
2020-05-11 17:39:49 New outbound peer connected: version: 70015, blocks=4520681, peer=3
2020-05-11 17:39:51 headers=84000(1.9%)
2020-05-11 17:39:52 headers=88000(1.9%)
2020-05-11 17:39:53 headers=90000(2.0%)
```