### PR TITLE
Revert "revert: MINIMUM_CONNECT_TIME"

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -41,7 +41,8 @@ static constexpr int64_t STALE_CHECK_INTERVAL = 5; // seconds // FIXME.SUGAR
 // sugarchain:  (5 / 3) = 1.666...
 static constexpr int64_t EXTRA_PEER_CHECK_INTERVAL = 3; // seconds // FIXME.SUGAR
 /** Minimum time an outbound-peer-eviction candidate must be connected for, in order to evict, in seconds */
-static constexpr int64_t MINIMUM_CONNECT_TIME = 30;
+// (30 / 2) = 15 
+static constexpr int64_t MINIMUM_CONNECT_TIME = 15; // seconds // FIXME.SUGAR
 
 class PeerLogicValidation : public CValidationInterface, public NetEventsInterface {
 private:


### PR DESCRIPTION
Reverts sugarchain-project/sugarchain#129

REASON: tests broken
```
Entering test suite "DoS_tests"
Entering test case "outbound_slow_chain_eviction"
Leaving test case "outbound_slow_chain_eviction"; testing time: 38901mks
Entering test case "stale_tip_peer_management"
test/DoS_tests.cpp(155): error in "stale_tip_peer_management": check vNodes.back()->fDisconnect == true failed
test/DoS_tests.cpp(167): error in "stale_tip_peer_management": check vNodes[nMaxOutbound-1]->fDisconnect == true failed
```