### PR TITLE
fix: travis: ImportError: No module named 'pathlib2'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - YESPOWER_MSSE2_32BIT="-msse2"
     - WIN_BITCOIN_CONFIG="--disable-shared"
   matrix:
-# ARM
+# ARM // why?
     - >
       HOST=arm-linux-gnueabihf
       PACKAGES="g++-arm-linux-gnueabihf python3-pip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ install:
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
-    - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then travis_retry pip3 install flake8 --user; fi
+    - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then travis_retry pip3 install flake8 pathlib2 --user; fi
 before_script:
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/crypto/ctaes; fi


### PR DESCRIPTION
```
  File "/home/travis/.local/lib/python3.4/site-packages/importlib_metadata/_compat.py", line 34, in <module>
    import pathlib2 as pathlib
ImportError: No module named 'pathlib2'
^---- failure generated from contrib/devtools/lint-python.sh
The command "if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/lint-all.sh; fi" failed and exited with 1 during .
```
![image](https://user-images.githubusercontent.com/60179867/82354529-e3928600-9a3b-11ea-8f4a-8ccd8ac3a296.png)
