### PR TITLE
[WIP2] option: -fastsync: Never check PoW during IBD

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -476,6 +476,7 @@ std::string HelpMessage(HelpMessageMode mode)
         CURRENCY_UNIT, FormatMoney(DEFAULT_TRANSACTION_MAXFEE)));
     strUsage += HelpMessageOpt("-printtoconsole", _("Send trace/debug info to console instead of debug.log file"));
     strUsage += HelpMessageOpt("-prunedebuglogfile", _("Prune (limit) filesize of debug.log")); // FIXME.SUGAR // prune debug.log
+    strUsage += HelpMessageOpt("-fastsync", _("Skip check PoW during IBD for faster sync")); // FIXME.SUGAR // Never check PoW during IBD
     if (showDebug)
     {
         strUsage += HelpMessageOpt("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY));
@@ -831,6 +832,7 @@ void InitLogging()
 {
     fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", false);
     fPruneDebugLog = gArgs.GetBoolArg("-prunedebuglogfile", false); // FIXME.SUGAR // prune debug.log
+    fFastSync = gArgs.GetBoolArg("-fastsync", false); // FIXME.SUGAR // Never check PoW during IBD
     fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);

--- a/src/validation.h
+++ b/src/validation.h
@@ -193,6 +193,8 @@ extern CAmount maxTxFee;
 extern int64_t nMaxTipAge;
 extern bool fEnableReplacement;
 
+extern bool fFastSync; // FIXME.SUGAR // Never check PoW during IBD
+
 /** Block hash whose ancestors we will assume to have valid scripts without checking them. */
 extern uint256 hashAssumeValid;
 


### PR DESCRIPTION
i am not sure, if this is good. however just testing case. in case ARM, sync seems too slow, due to lack of Yespower support.

- RAM usage is almost same
![image](https://user-images.githubusercontent.com/60179867/82358817-06279d80-9a42-11ea-90aa-1e0557c665e8.png)

- CPU usage much less
![image](https://user-images.githubusercontent.com/60179867/82358923-27888980-9a42-11ea-87c3-aba89b866608.png)
