### PR TITLE
add: mainnet dnsseed "seed.sugarchain.site"

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -259,6 +259,7 @@ public:
         // release ASAP to avoid it where possible.
         vSeeds.emplace_back("1seed.sugarchain.info"); // cryptozeny
         vSeeds.emplace_back("2seed.sugarchain.info"); // cryptozeny
+        vSeeds.emplace_back("seed.sugarchain.site"); // ROZ
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,63);  // legacy: starting with S (upper)
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,125); // p2sh-segwit: starting with s (lower)


### PR DESCRIPTION
Source: https://github.com/ROZ-MOFUMOFU-ME/sugarchain-seeder

- Show list
```bash
dig +short seed.sugarchain.site
```

- Test (`dnsutils` required)
```bash
> /tmp/dig_list_ip.txt && \
dig +short seed.sugarchain.site >> /tmp/dig_list_ip.txt && \
cat /tmp/dig_list_ip.txt && \
nmap -p 34230 -iL /tmp/dig_list_ip.txt
```
Result: `Nmap done: 14 IP addresses (7 hosts up) scanned in 3.20 seconds`
