### PR TITLE
add: mainnet dnsseed "seed.sugar.hel.lu"

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -259,6 +259,7 @@ public:
         vSeeds.emplace_back("1seed.sugarchain.info"); // cryptozeny
         vSeeds.emplace_back("2seed.sugarchain.info"); // cryptozeny
         vSeeds.emplace_back("seed.sugarchain.site"); // ROZ
+        vSeeds.emplace_back("seed.sugar.hel.lu"); // Hel
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,63);  // legacy: starting with S (upper)
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,125); // p2sh-segwit: starting with s (lower)


### PR DESCRIPTION
Source: https://github.com/lrhel/sugarchain-seeder

<details>
    <summary>dig +short seed.sugar.hel.lu</summary>
<pre class="ansi2html-content">
40.123.225.59
163.44.174.184
159.89.169.225
195.10.210.35
62.171.170.104
172.107.93.146
139.159.189.215
203.29.240.234
143.110.231.23
183.234.109.227
172.245.134.85
150.95.139.225
203.138.145.184
185.247.117.56
121.136.147.120
141.98.118.219
66.42.124.189
116.85.53.36
103.150.8.144
199.241.138.219
95.179.246.196
106.185.149.200
95.181.157.39
172.107.207.245
122.115.61.187

</pre>

</details>

<details>
<summary>nmap -p 34230 $(dig +short seed.sugar.hel.lu)</summary>
<pre>
Starting Nmap 7.91 ( https://nmap.org ) at 2021-02-10 11:58 UTC
Nmap scan report for v163-44-174-184.a06b.g.tyo1.static.cnode.io (163.44.174.184)
Host is up (0.25s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 203-138-145-184.indigo.static.arena.ne.jp (203.138.145.184)
Host is up (0.25s latency).

PORT      STATE  SERVICE
34230/tcp closed unknown

Nmap scan report for 141.98.118.219
Host is up (0.050s latency).

PORT      STATE  SERVICE
34230/tcp closed unknown

Nmap scan report for pics-img.localdomain (185.247.117.56)
Host is up (0.0011s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for v6stv4-106-185-149-200.21company.com (106.185.149.200)
Host is up (0.26s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 143.110.231.23
Host is up (0.15s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for x3g.vedekon.info (195.10.210.35)
Host is up (0.035s latency).

PORT      STATE  SERVICE
34230/tcp closed unknown

Nmap scan report for vmi395551.contaboserver.net (62.171.170.104)
Host is up (0.022s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for sg.mofumofu.me (199.241.138.219)
Host is up (0.19s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 172.245.134.85
Host is up (0.093s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 40.123.225.59
Host is up (0.13s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for mail.rightshopping.co.uk (172.107.93.146)
Host is up (0.17s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for v150-95-139-225.a084.g.tyo1.static.cnode.io (150.95.139.225)
Host is up (0.23s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 116.85.53.36
Host is up (0.22s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for unassigned.psychz.net (172.107.207.245)
Host is up (0.20s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 103.150.8.144
Host is up (0.25s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for ecs-139-159-189-215.compute.hwclouds-dns.com (139.159.189.215)
Host is up (0.21s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for cryptoyamafox.msk.network (95.181.157.39)
Host is up (0.051s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 122.115.61.187
Host is up (0.21s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap scan report for 121.136.147.120
Host is up (0.29s latency).

PORT      STATE SERVICE
34230/tcp open  unknown

Nmap done: 25 IP addresses (20 hosts up) scanned in 3.78 seconds

</pre>
</details>

<details>
<summary>
dnsseed.dump
</summary>
<pre>
# address                                        good  lastSuccess    %(2h)   %(8h)   %(1d)   %(7d)  %(30d)  blocks      svcs  version
94.23.29.122:34230                                  1   1612957748  100.00% 100.00% 100.00%  91.74%  44.11%  9268720  0000040d  70015 "/Yumekawa:0.16.3.30/"
150.95.139.225:34230                                1   1612957748  100.00% 100.00% 100.00%  91.74%  44.11%  9268722  0000040d  70015 "/Yumekawa:0.16.3.35/"
66.42.124.189:34230                                 1   1612957748  100.00% 100.00% 100.00%  91.74%  44.11%  9268722  0000040d  70015 "/Yumekawa:0.16.3.33/"
158.101.131.198:34230                               1   1612957748  100.00% 100.00% 100.00%  91.74%  44.11%  9268720  0000040d  70015 "/Yumekawa:0.16.3.34/"
143.110.231.23:34230                                1   1612957625  100.00% 100.00% 100.00%  91.73%  44.11%  9268692  0000040d  70015 "/Yumekawa:0.16.3.34/"
167.71.20.240:34230                                 1   1612957946  100.00% 100.00% 100.00%  91.73%  44.11%  9268763  0000040d  70015 "/Yumekawa:0.16.3.30/"
62.171.170.104:34230                                1   1612957625  100.00% 100.00% 100.00%  91.73%  44.11%  9268693  0000040d  70015 "/Yumekawa:0.16.3.33/"
163.44.174.184:34230                                1   1612957231  100.00% 100.00% 100.00%  91.73%  44.10%  9268597  0000040d  70015 "/Yumekawa:0.16.3.24/"
172.107.207.245:34230                               1   1612957946  100.00% 100.00% 100.00%  91.68%  44.08%  9268763  0000040d  70015 "/Yumekawa:0.16.3.35/"
95.179.246.196:34230                                1   1612957748  100.00% 100.00%  99.99%  91.65%  44.07%  9268722  0000040d  70015 "/Yumekawa:0.16.3.33/"
121.136.147.120:34230                               1   1612957625  100.00% 100.00% 100.00%  91.67%  44.07%  9268693  0000040d  70015 "/Yumekawa:0.16.3.21/"
159.89.169.225:34230                                1   1612957625  100.00% 100.00% 100.00%  91.67%  44.07%  9268693  0000040d  70015 "/Yumekawa:0.16.3.33/"
203.29.240.234:34230                                1   1612957231  100.00% 100.00% 100.00%  91.67%  44.07%  9268597  0000040d  70015 "/Yumekawa:0.16.3.34/"
172.107.93.146:34230                                1   1612957231  100.00% 100.00% 100.00%  91.65%  44.06%  9268598  0000040d  70015 "/Yumekawa:0.16.3.34/"
199.241.138.219:34230                               1   1612957748  100.00% 100.00% 100.00%  91.63%  44.05%  9268722  0000040d  70015 "/Yumekawa:0.16.3.34/"
103.150.8.144:34230                                 1   1612957231  100.00% 100.00% 100.00%  91.61%  44.03%  9268597  0000040d  70015 "/Yumekawa:0.16.3.34/"
172.245.134.85:34230                                1   1612957748  100.00% 100.00% 100.00%  91.60%  44.00%  9268720  0000040d  70015 "/Yumekawa:0.16.3.34/"
202.5.24.215:34230                                  1   1612957625   88.26%  96.56%  98.74%  91.29%  43.94%  9268693  0000040d  70015 "/Yumekawa:0.16.3.34/"
40.123.225.59:34230                                 1   1612957625  100.00%  99.75%  99.50%  91.39%  43.93%  9268691  0000040d  70015 "/Yumekawa:0.16.3.34/"
185.247.117.56:34230                                1   1612957231  100.00% 100.00% 100.00%  91.55%  43.92%  9268597  0000040d  70015 "/Yumekawa:0.16.3.36/"
195.10.210.35:34230                                 1   1612952694   49.56%  83.90%  94.31%  90.71%  43.82%  9267716  0000040d  70015 "/Yumekawa:0.16.3.35/"
122.115.61.187:34230                                1   1612958013  100.00% 100.00%  99.90%  91.17%  43.73%  7065849  0000040d  70015 "/Yumekawa:0.16.3.34/"
116.85.53.36:34230                                  1   1612957523  100.00%  99.78%  99.52%  90.95%  43.64%  9268671  0000040d  70015 "/Yumekawa:0.16.3.34/"
203.138.145.184:34230                               1   1612940267    8.97%  54.73%  81.67%  88.78%  43.40%  9265294  0000040d  70015 "/Yumekawa:0.16.3.34/"
139.159.189.215:34230                               1   1612957625   99.93%  99.05%  98.97%  89.07%  42.35%  9268691  0000040d  70015 "/Yumekawa:0.16.3.34/"
183.234.109.227:34230                               1   1612957625  100.00% 100.00%  99.55%  86.19%  41.00%  9268693  0000040d  70015 "/Yumekawa:0.16.3.34/"
116.46.150.4:34230                                  1   1612957523  100.00% 100.00%  99.95%  85.02%  38.36%  9268670  0000040d  70015 "/Yumekawa:0.16.3.24/"
106.185.149.200:34230                               1   1612957231  100.00% 100.00% 100.00%  76.74%  28.84%  9268598  0000040d  70015 "/Yumekawa:0.16.3.34/"
23.94.82.234:34230                                  1   1612957748  100.00%  99.84%  98.54%  65.28%  22.08%  9268720  0000040d  70015 "/Yumekawa:0.16.3.36/"
132.232.74.176:34230                                1   1612957946   94.42%  63.70%  48.62%  42.37%  19.64%  9268755  0000040d  70015 "/Yumekawa:0.16.3.34/"
106.53.236.90:34230                                 1   1612957946  100.00% 100.00%  99.33%  51.48%  15.54%  9268763  0000040d  70015 "/Yumekawa:0.16.3.34/"
97.64.114.233:34230                                 0   1612130287   62.66%  26.76%  35.66%  36.69%  13.27%  9103443  0000040d  70015 "/Yumekawa:0.16.3.36/"
62.171.139.192:34230                                0   1612942111   11.00%  36.77%  41.78%  28.88%   9.74%  9265651  0000040d  70015 "/Yumekawa:0.16.3.36/"
193.227.165.196:34230                               0   1611771661   58.05%  23.81%  39.53%  28.17%   8.41%  9031813  0000040d  70015 "/Yumekawa:0.16.3.34/"
213.241.84.58:34230                                 1   1611778470   98.42%  64.61%  33.72%  12.70%   3.70%  9033193  0000040d  70015 "/Yumekawa:0.16.3.35/"
149.154.64.253:34230                                0   1611766773   22.34%  29.06%  17.50%   5.60%   1.57%  9030860  0000040d  70015 "/Yumekawa:0.16.3.24/"
51.79.177.216:34230                                 0   1611652363   34.74%  15.97%  12.05%   3.60%   0.94%  9008045  0000040d  70015 "/Yumekawa:0.16.3.35/"
61.54.187.9:34230                                   0   1611564079   63.60%  22.33%   8.08%   1.20%   0.28%  8990470  0000040d  70015 "/Yumekawa:0.16.3.34/"

</pre>
</details>

Additionally, the domain `hel.lu` is pre-paid until 2023 (2 years)