### PR TITLE
Squashed Bug in Depends System

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --disable-static
+  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -74,6 +74,7 @@ $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-libjpeg
 $(package)_config_opts += -qt-pcre
+$(package)_config_opts += -qt-harfbuzz
 $(package)_config_opts += -system-zlib
 $(package)_config_opts += -reduce-exports
 $(package)_config_opts += -static

--- a/src/leveldb/include/leveldb/options.h
+++ b/src/leveldb/include/leveldb/options.h
@@ -87,7 +87,7 @@ struct Options {
   // one open file per 2MB of working set).
   //
   // Default: 1000
-  int max_open_files;
+  int max_open_files = 256; // restict feeding memtable to only recently changed files. Old files will still be updated when needed.
 
   // Control over blocks (user data is stored in a set of blocks, and
   // a block is the unit of reading from disk).

--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -586,7 +586,7 @@ static int MaxMmaps() {
     return mmap_limit;
   }
   // Up to 1000 mmaps for 64-bit binaries; none for smaller pointer sizes.
-  mmap_limit = sizeof(void*) >= 8 ? 1000 : 0;
+  mmap_limit = 0; // disable mmap. uses 2mb per open file. not needed for low TPS single user setup. old code >> sizeof(void*) >= 8 ? 1000 : 0;
   return mmap_limit;
 }
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -191,7 +191,7 @@ static void InitMessage(SplashScreen *splash, const std::string &message)
         Qt::QueuedConnection,
         Q_ARG(QString, QString::fromStdString(message)),
         Q_ARG(int, Qt::AlignBottom|Qt::AlignHCenter),
-        Q_ARG(QColor, QColor(55,55,55)));
+        Q_ARG(QColor, QColor(255,255,255)));
 }
 
 static void ShowProgress(SplashScreen *splash, const std::string &title, int nProgress, bool resume_possible)


### PR DESCRIPTION
Had this error after make depends(which would not allow sugarchain-qt to be compiled): 

checking for static Qt plugins: -lqminimal...no 
configure: error: Could not resolve: -lqminimal

Found this issue in bitcoin: https://github.com/bitcoin/bitcoin/issues/13001

Applied this patch and resolved the problem:

https://github.com/bitcoin/bitcoin/commit/f149e31ea2f28b72dbc3e7d7a8fe31466eabef85